### PR TITLE
Day03

### DIFF
--- a/exercise/ts/day00/tests/encryption.spec.ts
+++ b/exercise/ts/day00/tests/encryption.spec.ts
@@ -32,11 +32,4 @@ describe("Encryption", () => {
       })
     );
   });
-
-  test("should decrypt email", () => {
-    const email = loadFile("EncryptedEmail.txt");
-    expect(encryption.decrypt(email)).toBe(
-      "Dear consultant,\n\nWe are facing an unprecedented challenge in Christmas Town.\n\nThe systems that keep our magical operations running smoothly are outdated, fragile, and in dire need of modernization. \nWe urgently require your expertise to ensure Christmas happens this year.\nOur town is located within a mountain circlet at the North Pole, surrounded by high peaks and protected by an advanced communication and shield system to hide it from the outside world.\n\nYou have been selected for your exceptional skills and dedication. \nPlease report to the North Pole immediately. \n\nEnclosed are your travel details and a non-disclosure agreement that you must sign upon arrival.\nOur dwarf friends from the security will receive and escort you in as soon as you check security.\nIn the following days, you will receive bracelets to be able to pass through the magic shield.\n\nTime is of the essence.\nYou must arrive before the beginning of December to be able to acclimate yourself with all the systems.\n\nWe are counting on you to help save Christmas.\n\nSincerely,\n\nSanta Claus 🎅"
-    );
-  });
 });

--- a/exercise/ts/day03/package-lock.json
+++ b/exercise/ts/day03/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gift-preparation",
       "version": "1.0.0",
       "dependencies": {
+        "fast-check": "^3.23.1",
         "typescript": "^5.3.3"
       },
       "devDependencies": {
@@ -1674,6 +1675,27 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.1.tgz",
+      "integrity": "sha512-u/MudsoQEgBUZgR5N1v87vEgybeVYus9VnDVaIkxkkGP2jt54naghQ3PCQHJiogS8U/GavZCUPFfx3Xkp+NaHw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3104,7 +3126,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",

--- a/exercise/ts/day03/package.json
+++ b/exercise/ts/day03/package.json
@@ -2,12 +2,13 @@
   "name": "gift-preparation",
   "version": "1.0.0",
   "dependencies": {
+    "fast-check": "^3.23.1",
     "typescript": "^5.3.3"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.8",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.8"
+    "ts-jest": "^29.1.1"
   },
   "scripts": {
     "test": "jest"

--- a/exercise/ts/day03/src/gift.ts
+++ b/exercise/ts/day03/src/gift.ts
@@ -1,3 +1,5 @@
+const recommendedAgeKey = "recommendedAge";
+const assignedGiftKey = "assignedTo";
 export class Gift {
   private readonly attributes: Map<string, string> = new Map<string, string>();
 
@@ -25,7 +27,7 @@ export class Gift {
   }
 
   public assignToChild(childName: string): void {
-    this.addAttribute("assignedTo", childName);
+    this.addAttribute(assignedGiftKey, childName);
   }
 
   public addAttribute(key: string, value: string): void {
@@ -37,7 +39,7 @@ export class Gift {
   }
 
   public getRecommendedAge(): number {
-    const recommendedAge = this.attributes.get("recommendedAge");
+    const recommendedAge = this.attributes.get(recommendedAgeKey);
     return recommendedAge ? parseInt(recommendedAge, 10) : 0;
   }
 

--- a/exercise/ts/day03/src/gift.ts
+++ b/exercise/ts/day03/src/gift.ts
@@ -1,27 +1,47 @@
 export class Gift {
-    private attributes: Map<string, string> = new Map<string, string>();
+  private readonly attributes: Map<string, string> = new Map<string, string>();
 
-    constructor(
-        private readonly name: string,
-        private readonly weight: number,
-        private readonly color: string,
-        private readonly material: string,
-    ) {
-    }
+  constructor(
+    private readonly name: string,
+    private readonly weight: number,
+    private readonly color: string,
+    private readonly material: string
+  ) {}
 
-    public assignToChild(childName: string): void {
-    }
+  public getName(): string {
+    return this.name;
+  }
 
-    public addAttribute(key: string, value: string): void {
-        this.attributes.set(key, value);
-    }
+  public getWeight(): number {
+    return this.weight;
+  }
 
-    public getRecommendedAge(): number {
-        const recommendedAge = this.attributes.get('recommendedAge');
-        return recommendedAge ? parseInt(recommendedAge, 10) : 0;
-    }
+  public getColor(): string {
+    return this.color;
+  }
 
-    public toString(): string {
-        return `A ${this.color}-colored ${this.name} weighing ${this.weight} kg made in ${this.material}`;
-    }
+  public getMaterial(): string {
+    return this.material;
+  }
+
+  public assignToChild(childName: string): void {
+    this.addAttribute("assignedTo", childName);
+  }
+
+  public addAttribute(key: string, value: string): void {
+    this.attributes.set(key, value);
+  }
+
+  public getAttribute(key: string): string | undefined {
+    return this.attributes.get(key);
+  }
+
+  public getRecommendedAge(): number {
+    const recommendedAge = this.attributes.get("recommendedAge");
+    return recommendedAge ? parseInt(recommendedAge, 10) : 0;
+  }
+
+  public toString(): string {
+    return `A ${this.color}-colored ${this.name} weighing ${this.weight} kg made in ${this.material}`;
+  }
 }

--- a/exercise/ts/day03/src/santaWorkshopService.ts
+++ b/exercise/ts/day03/src/santaWorkshopService.ts
@@ -1,16 +1,27 @@
-import { Gift } from './gift';
+import { Gift } from "./gift";
+
+type GiftConfig = {
+  giftName: string;
+  weight: number;
+  color: string;
+  material: string;
+};
 
 export class SantaWorkshopService {
-    private preparedGifts: Gift[] = [];
+  private readonly preparedGifts: Gift[] = [];
 
-    public prepareGift(giftName: string, weight: number, color: string, material: string): Gift {
-        if (weight > 5) {
-            throw new Error('Gift is too heavy for Santa\'s sleigh');
-        }
-
-        const gift = new Gift(giftName, weight, color, material);
-        this.preparedGifts.push(gift);
-
-        return gift;
+  public prepareGift(giftConfig: GiftConfig): Gift {
+    const { giftName, weight, color, material } = giftConfig;
+    if (weight > 5) {
+      throw new Error("Gift is too heavy for Santa's sleigh");
     }
+    if (!giftName || !color || !material) {
+      throw new Error("Gift is missing required parameters");
+    }
+
+    const gift = new Gift(giftName, weight, color, material);
+    this.preparedGifts.push(gift);
+
+    return gift;
+  }
 }

--- a/exercise/ts/day03/src/santaWorkshopService.ts
+++ b/exercise/ts/day03/src/santaWorkshopService.ts
@@ -1,19 +1,19 @@
 import { Gift } from "./gift";
 
-type GiftConfig = {
+export type GiftConfig = {
   giftName: string;
   weight: number;
   color: string;
   material: string;
 };
 
-const sleighWeightLimit = 5;
+export const SLEIGH_WEIGHT_LIMIT = 5;
 export class SantaWorkshopService {
   private readonly preparedGifts: Gift[] = [];
 
   public prepareGift(giftConfig: GiftConfig): Gift {
     const { giftName, weight, color, material } = giftConfig;
-    if (weight > sleighWeightLimit) {
+    if (weight > SLEIGH_WEIGHT_LIMIT) {
       throw new Error("Gift is too heavy for Santa's sleigh");
     }
     if (!giftName) {

--- a/exercise/ts/day03/src/santaWorkshopService.ts
+++ b/exercise/ts/day03/src/santaWorkshopService.ts
@@ -7,16 +7,23 @@ type GiftConfig = {
   material: string;
 };
 
+const sleighWeightLimit = 5;
 export class SantaWorkshopService {
   private readonly preparedGifts: Gift[] = [];
 
   public prepareGift(giftConfig: GiftConfig): Gift {
     const { giftName, weight, color, material } = giftConfig;
-    if (weight > 5) {
+    if (weight > sleighWeightLimit) {
       throw new Error("Gift is too heavy for Santa's sleigh");
     }
-    if (!giftName || !color || !material) {
-      throw new Error("Gift is missing required parameters");
+    if (!giftName) {
+      throw new Error("Gift is missing the required parameter: giftName");
+    }
+    if (!color) {
+      throw new Error("Gift is missing the required parameter: color");
+    }
+    if (!material) {
+      throw new Error("Gift is missing the required parameter: material");
     }
 
     const gift = new Gift(giftName, weight, color, material);

--- a/exercise/ts/day03/tests/santaWorkshopService.spec.ts
+++ b/exercise/ts/day03/tests/santaWorkshopService.spec.ts
@@ -1,42 +1,94 @@
-import {SantaWorkshopService} from "../src/santaWorkshopService";
-import {Gift} from "../src/gift";
+import { SantaWorkshopService } from "../src/santaWorkshopService";
+import { Gift } from "../src/gift";
+import fc from "fast-check";
 
-describe('SantaWorkshopService', () => {
-    let service: SantaWorkshopService;
+const giftCongig = {
+  giftName: "Furby",
+  weight: 1,
+  color: "Multi",
+  material: "Cotton",
+};
+describe("SantaWorkshopService", () => {
+  let service: SantaWorkshopService;
 
-    beforeEach(() => {
-        service = new SantaWorkshopService();
-    });
+  beforeEach(() => {
+    service = new SantaWorkshopService();
+  });
 
-    it('should prepare a gift with valid parameters', () => {
-        const giftName = 'Bitzee';
-        const weight = 3;
-        const color = 'Purple';
-        const material = 'Plastic';
+  it("should prepare a gift with valid parameters", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5 }),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 }),
+        (weight, giftName, color, material) => {
+          const gift = service.prepareGift({
+            weight,
+            giftName,
+            color,
+            material,
+          });
+          expect(gift).toBeInstanceOf(Gift);
+          expect(gift.getName()).toBe(giftName);
+          expect(gift.getWeight()).toBe(weight);
+          expect(gift.getColor()).toBe(color);
+          expect(gift.getMaterial()).toBe(material);
+        }
+      )
+    );
+  });
 
-        const gift = service.prepareGift(giftName, weight, color, material);
+  it("should throw an error if gift is too heavy", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 6, max: 10000000 }),
+        fc.string(),
+        fc.string(),
+        fc.string(),
+        (weight, giftName, color, material) => {
+          expect(() =>
+            service.prepareGift({ giftName, weight, color, material })
+          ).toThrow("Gift is too heavy for Santa's sleigh");
+        }
+      )
+    );
+  });
 
-        expect(gift).toBeInstanceOf(Gift);
-    });
+  it("should add an attribute to a gift", () => {
+    const gift = service.prepareGift(giftCongig);
 
-    it('should throw an error if gift is too heavy', () => {
-        const giftName = 'Dog-E';
-        const weight = 6;
-        const color = 'White';
-        const material = 'Metal';
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, unit: "grapheme" }),
+        fc.string({ minLength: 0, unit: "grapheme" }),
+        (key, value) => {
+          gift.addAttribute(key, value);
+          expect(gift.getAttribute(key)).toBe(value);
+        }
+      )
+    );
+  });
 
-        expect(() => service.prepareGift(giftName, weight, color, material)).toThrow('Gift is too heavy for Santa\'s sleigh');
-    });
+  it("should add an recommendedAge attribute to a gift", () => {
+    const gift = service.prepareGift(giftCongig);
 
-    it('should add an attribute to a gift', () => {
-        const giftName = 'Furby';
-        const weight = 1;
-        const color = 'Multi';
-        const material = 'Cotton';
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 99 }), (value) => {
+        gift.addAttribute("recommendedAge", value.toString());
+        expect(gift.getRecommendedAge()).toBe(value);
+      })
+    );
+  });
 
-        const gift = service.prepareGift(giftName, weight, color, material);
-        gift.addAttribute('recommendedAge', '3');
+  it("should assign a gift to a child", () => {
+    const gift = service.prepareGift(giftCongig);
 
-        expect(gift.getRecommendedAge()).toBe(3);
-    });
+    fc.assert(
+      fc.property(fc.string({ unit: "grapheme" }), (childName) => {
+        gift.assignToChild(childName);
+        expect(gift.getAttribute("assignedTo")).toBe(childName);
+      })
+    );
+  });
 });


### PR DESCRIPTION
feat: enhance gift preparation and assignment

Add readonly to fields assigned only in the constructor.
Rewrite all tests using fast-check.
Add a getAttributeMethod to test various addAttributes cases.
Change prepareGift parameter to an object for better flexibility.
Add a GiftConfig type used by prepareGift.
Add parameter checks for better robustness.
Add a test to ensure a gift is assigned to a child.
Complete the assignToChild method.
Add constants for the sleigh weight limit, assignToKey, and recommendedAgeKey.